### PR TITLE
support webpack.config.js "stats" from the CLI

### DIFF
--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -65,13 +65,11 @@ function ifArg(name, fn, init) {
 	}
 }
 
+var outputOptions = options.stats || {};
 
-
-var outputOptions = {
-	cached: false,
-	cachedAssets: false,
-	context: options.context
-};
+outputOptions.cached = false;
+outputOptions.cachedAssets = false;
+outputOptions.context = false;
 
 ifArg("json", function(bool) {
 	outputOptions.json = bool;


### PR DESCRIPTION
I made "stats" the base object for outputOptions since there is no `Object.assign` available. Comment with any concerns. Thanks!